### PR TITLE
removed automatic export of definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ definition:
 
 <pre>(define-tuple <i>type</i> (<i>field-name</i> ...))</pre>
 
+Each message definition uses <tt>define-property</tt> to associate the
+procedures that read, size, merge, and write it with _type_.
+
 #### Enumeration definitions
 
 <pre>(define-enum <i>type</i> (<i>name</i> <i>value</i>) ...)</pre>
@@ -36,7 +39,6 @@ there is not a guaranteed one-to-one mapping from values to symbols.
 
 #### Limitations
 
-- Message and enumeration definitions are automatically exported. As a result, the <tt>define-message</tt> and <tt>define-enum</tt> forms must be used within a library or module. The message definitions use <tt>define-property</tt> to associate the procedures that read, size, merge, and write them with the name of the message.
 - One-of fields are treated like regular fields.
 - Groups and extensions are not supported.
 - The writer does not honor the <tt>[packed=false]</tt> option, but the reader supports both packed and unpacked repeated scalar numeric fields.

--- a/protobuf.ss
+++ b/protobuf.ss
@@ -38,14 +38,12 @@
        (and (identifier? #'type)
             (andmap identifier? #'(key ...))
             (andmap integer? (datum (value ...))))
-       (begin
-         (define-syntax (type x)
-           (syntax-case x ()
-             [(_ s)
-              (cond
-               [(assq (datum s) '((key . value) ...)) => cdr]
-               [else (syntax-error x "unknown enum member")])]))
-         (export type))]))
+       (define-syntax (type x)
+         (syntax-case x ()
+           [(_ s)
+            (cond
+             [(assq (datum s) '((key . value) ...)) => cdr]
+             [else (syntax-error x "unknown enum member")])]))]))
 
   (define-syntax (define-message x)
     (define (fresh-id prefix stype)
@@ -90,8 +88,7 @@
              (define-property type *merger* #'merge-type)
              (define-property type *reader* #'read-type)
              (define-property type *sizer* #'size-type)
-             (define-property type *writer* #'write-type)
-             (export type)))]))
+             (define-property type *writer* #'write-type)))]))
 
   (define-syntax read-message
     (syntax-rules ()


### PR DESCRIPTION
The automatic export makes the definitions inconsistent with standard definitions and did not turn out to be useful for us after all.